### PR TITLE
small poc with some examples

### DIFF
--- a/error.go
+++ b/error.go
@@ -27,6 +27,27 @@ func (k *Kind) Wrap(err error) *Error {
 	}
 }
 
+func (k *Kind) Is(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	e, ok := err.(*Error)
+	if !ok {
+		return false
+	}
+
+	if k == e.Kind {
+		return true
+	}
+
+	if e.Child == nil {
+		return false
+	}
+
+	return k.Is(e.Child)
+}
+
 func (k *Kind) Match(required ...*Kind) bool {
 
 	for _, kind := range required {

--- a/error.go
+++ b/error.go
@@ -1,0 +1,54 @@
+package errors
+
+import (
+	"fmt"
+)
+
+func New(msg string) *Kind {
+	return &Kind{Message: msg}
+}
+
+type Kind struct {
+	Message string
+}
+
+func (k *Kind) New(values ...interface{}) *Error {
+	return &Error{
+		Kind:    k,
+		Message: fmt.Sprintf(k.Message, values...),
+	}
+}
+
+func (k *Kind) Wrap(err error) *Error {
+	return &Error{
+		Kind:    k,
+		Child:   err,
+		Message: k.Message + ": %s",
+	}
+}
+
+func (k *Kind) Match(required ...*Kind) bool {
+
+	for _, kind := range required {
+		if k == kind {
+			return true
+		}
+	}
+
+	return false
+}
+
+type Error struct {
+	Kind    *Kind
+	Child   error
+	Message string
+}
+
+func (err *Error) Error() string {
+	if err.Child == nil {
+
+		return err.Message
+	}
+
+	return fmt.Sprintf(err.Message, err.Child.Error())
+}

--- a/example_test.go
+++ b/example_test.go
@@ -11,7 +11,7 @@ func ExampleNew() {
 	var ErrExample = errors.New("example")
 
 	err := ErrExample.New()
-	if errors.Is(err, ErrExample) {
+	if ErrExample.Is(err) {
 		fmt.Println(err)
 	}
 
@@ -22,7 +22,7 @@ func ExampleNewFormat() {
 	var ErrMaxLimitReached = errors.New("max. limit reached: %d")
 
 	err := ErrMaxLimitReached.New(42)
-	if errors.Is(err, ErrMaxLimitReached) {
+	if ErrMaxLimitReached.Is(err) {
 		fmt.Println(err)
 	}
 
@@ -33,7 +33,7 @@ func ExampleWrap() {
 	var ErrNetworking = errors.New("network error")
 
 	err := ErrNetworking.Wrap(io.EOF)
-	if errors.Is(err, ErrNetworking) {
+	if ErrNetworking.Is(err) {
 		fmt.Println(err)
 	}
 
@@ -47,9 +47,21 @@ func ExampleNestedWrap() {
 	err3 := io.EOF
 	err2 := ErrReading.Wrap(err3)
 	err1 := ErrNetworking.Wrap(err2)
-	if errors.Is(err1, ErrReading) {
+	if ErrReading.Is(err1) {
 		fmt.Println(err1)
 	}
 
 	// Output: network error: reading error: EOF
+}
+
+func ExampleAlternativeMultiple() {
+	var ErrNetworking = errors.New("network error")
+	var ErrReading = errors.New("reading error")
+
+	err := ErrNetworking.New()
+	if errors.Is(err, ErrReading, ErrNetworking) {
+		fmt.Println(err)
+	}
+
+	// Output: network error
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,55 @@
+package errors_test
+
+import (
+	"fmt"
+	"io"
+
+	"srcd.works/errors.v0"
+)
+
+func ExampleNew() {
+	var ErrExample = errors.New("example")
+
+	err := ErrExample.New()
+	if errors.Is(err, ErrExample) {
+		fmt.Println(err)
+	}
+
+	// Output: example
+}
+
+func ExampleNewFormat() {
+	var ErrMaxLimitReached = errors.New("max. limit reached: %d")
+
+	err := ErrMaxLimitReached.New(42)
+	if errors.Is(err, ErrMaxLimitReached) {
+		fmt.Println(err)
+	}
+
+	// Output: max. limit reached: 42
+}
+
+func ExampleWrap() {
+	var ErrNetworking = errors.New("network error")
+
+	err := ErrNetworking.Wrap(io.EOF)
+	if errors.Is(err, ErrNetworking) {
+		fmt.Println(err)
+	}
+
+	// Output: network error: EOF
+}
+
+func ExampleNestedWrap() {
+	var ErrNetworking = errors.New("network error")
+	var ErrReading = errors.New("reading error")
+
+	err3 := io.EOF
+	err2 := ErrReading.Wrap(err3)
+	err1 := ErrNetworking.Wrap(err2)
+	if errors.Is(err1, ErrReading) {
+		fmt.Println(err1)
+	}
+
+	// Output: network error: reading error: EOF
+}

--- a/matcher.go
+++ b/matcher.go
@@ -1,0 +1,33 @@
+package errors
+
+type Matcher interface {
+	Match(required ...*Kind) bool
+}
+
+func Is(err error, matchers ...Matcher) bool {
+	if err == nil {
+		return false
+	}
+
+	e, ok := err.(*Error)
+	if !ok {
+		return false
+	}
+
+	if e.Child != nil && Is(e.Child, matchers...) {
+		return true
+	}
+
+	for _, m := range matchers {
+		if m.Match(e.Kind) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (k *Kind) matchChild(required ...*Kind) bool {
+
+	return false
+}


### PR DESCRIPTION
The main goal of this package is having a more versatile standard errors, since some times specially in go-git we are having [var blocks](https://dave.cheney.net/2014/12/24/inspecting-errors) containing standard errors:

```go
var (
	ErrObjectNotFound     = errors.New("object not found")
	ErrInvalidReference   = errors.New("invalid reference, should be a tag or a branch")
	ErrRepositoryNonEmpty = errors.New("repository non empty")
	ErrRemoteNotFound     = errors.New("remote not found")
	ErrRemoteExists       = errors.New("remote already exists")
)
```

Usually we assert the returned error comparing if to the pointer:
```go 
err := git.Clone()
if err != nil {
     if err == ErrRemoteNotFound {
         // handling specific behaviour
     }
}
```

This kind of errors doesn't allow more verbose info, like having the URL of the `ErrRemoteNotFound` repository for example.

So this is a small PoC trying to solve this, ideally not required to import this `errors` library to people using for example `go-git`, something that I find interesting, mainly because you will end with conflicts with this custom error package and the standard one.

As an extra perk I plan to add the callstack to the Error, similar as do this library:
https://github.com/pkg/errors 

please checkout the `example_test.go` it contains a few examples of the suggested uses.