### PR TITLE
implementation and tests

### DIFF
--- a/error.go
+++ b/error.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-// Kind represents a kind of an error, from a Kind you can generate as many
+// Kind represents the kind as an error, from a Kind you can generate as many
 // Error instances of you want of this Kind
 type Kind struct {
 	Message string
@@ -24,7 +24,7 @@ func (k *Kind) New(values ...interface{}) *Error {
 	}
 }
 
-// Wrap create a new Error of this Kind with cause error
+// Wrap creates a new Error of this Kind with the cause error
 func (k *Kind) Wrap(cause error) *Error {
 	return &Error{
 		Kind:    k,
@@ -33,7 +33,7 @@ func (k *Kind) Wrap(cause error) *Error {
 	}
 }
 
-// Is checks if the given error or any of his children are of this Kind
+// Is checks if the given error or any of its children are of this Kind
 func (k *Kind) Is(err error) bool {
 	if err == nil {
 		return false

--- a/error.go
+++ b/error.go
@@ -4,14 +4,19 @@ import (
 	"fmt"
 )
 
-func New(msg string) *Kind {
-	return &Kind{Message: msg}
-}
-
+// Kind represents a kind of an error, from a Kind you can generate as many
+// Error instances of you want of this Kind
 type Kind struct {
 	Message string
 }
 
+// New returns a Kind with the given msg
+func New(msg string) *Kind {
+	return &Kind{Message: msg}
+}
+
+// New returns a new Error, values can be pass to it if the Kind was created
+// using an printf format
 func (k *Kind) New(values ...interface{}) *Error {
 	return &Error{
 		Kind:    k,
@@ -19,14 +24,16 @@ func (k *Kind) New(values ...interface{}) *Error {
 	}
 }
 
-func (k *Kind) Wrap(err error) *Error {
+// Wrap create a new Error of this Kind with cause error
+func (k *Kind) Wrap(cause error) *Error {
 	return &Error{
 		Kind:    k,
-		Child:   err,
+		Cause:   cause,
 		Message: k.Message + ": %s",
 	}
 }
 
+// Is checks if the given error or any of his children are of this Kind
 func (k *Kind) Is(err error) bool {
 	if err == nil {
 		return false
@@ -41,35 +48,27 @@ func (k *Kind) Is(err error) bool {
 		return true
 	}
 
-	if e.Child == nil {
+	if e.Cause == nil {
 		return false
 	}
 
-	return k.Is(e.Child)
+	return k.Is(e.Cause)
 }
 
-func (k *Kind) Match(required ...*Kind) bool {
-
-	for _, kind := range required {
-		if k == kind {
-			return true
-		}
-	}
-
-	return false
-}
-
+// Error represents an error of some Kind, implements the error interface
 type Error struct {
-	Kind    *Kind
-	Child   error
+	// Kind is a pointer to the Kind of this error
+	Kind *Kind
+	// Cause of the error
+	Cause error
+	// Message describing the error
 	Message string
 }
 
 func (err *Error) Error() string {
-	if err.Child == nil {
-
+	if err.Cause == nil {
 		return err.Message
 	}
 
-	return fmt.Sprintf(err.Message, err.Child.Error())
+	return fmt.Sprintf(err.Message, err.Cause.Error())
 }

--- a/error.go
+++ b/error.go
@@ -10,8 +10,8 @@ type Kind struct {
 	Message string
 }
 
-// New returns a Kind with the given msg
-func New(msg string) *Kind {
+// NewKind returns a Kind with the given msg
+func NewKind(msg string) *Kind {
 	return &Kind{Message: msg}
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -8,26 +8,26 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	k := New("foo")
+	k := NewKind("foo")
 	assert.Equal(t, k.Message, "foo")
 }
 
 func TestKindNew(t *testing.T) {
-	k := New("foo")
+	k := NewKind("foo")
 	err := k.New()
 	assert.Equal(t, err.Message, "foo")
 	assert.Equal(t, err.Kind, k)
 }
 
 func TestKindNewWithFormat(t *testing.T) {
-	k := New("foo %s")
+	k := NewKind("foo %s")
 	err := k.New("bar")
 	assert.Equal(t, err.Message, "foo bar")
 	assert.Equal(t, err.Kind, k)
 }
 
 func TestKindWrap(t *testing.T) {
-	k := New("foo")
+	k := NewKind("foo")
 	err := k.Wrap(io.EOF)
 	assert.Equal(t, err.Message, "foo: %s")
 	assert.Equal(t, err.Kind, k)
@@ -35,7 +35,7 @@ func TestKindWrap(t *testing.T) {
 }
 
 func TestKindIs(t *testing.T) {
-	k := New("foo")
+	k := NewKind("foo")
 	err := k.New("bar")
 	assert.Equal(t, k.Is(err), true)
 	assert.Equal(t, k.Is(io.EOF), false)
@@ -43,17 +43,17 @@ func TestKindIs(t *testing.T) {
 }
 
 func TestKindIsChildren(t *testing.T) {
-	k := New("foo")
+	k := NewKind("foo")
 	err := k.Wrap(io.EOF)
 	assert.Equal(t, k.Is(err), true)
 }
 
 func TestError(t *testing.T) {
-	err := New("foo %s").New("bar")
+	err := NewKind("foo %s").New("bar")
 	assert.Equal(t, err.Error(), "foo bar")
 }
 
 func TestErrorCause(t *testing.T) {
-	err := New("foo").Wrap(io.EOF)
+	err := NewKind("foo").Wrap(io.EOF)
 	assert.Equal(t, err.Error(), "foo: EOF")
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,59 @@
+package errors
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	k := New("foo")
+	assert.Equal(t, k.Message, "foo")
+}
+
+func TestKindNew(t *testing.T) {
+	k := New("foo")
+	err := k.New()
+	assert.Equal(t, err.Message, "foo")
+	assert.Equal(t, err.Kind, k)
+}
+
+func TestKindNewWithFormat(t *testing.T) {
+	k := New("foo %s")
+	err := k.New("bar")
+	assert.Equal(t, err.Message, "foo bar")
+	assert.Equal(t, err.Kind, k)
+}
+
+func TestKindWrap(t *testing.T) {
+	k := New("foo")
+	err := k.Wrap(io.EOF)
+	assert.Equal(t, err.Message, "foo: %s")
+	assert.Equal(t, err.Kind, k)
+	assert.Equal(t, err.Cause, io.EOF)
+}
+
+func TestKindIs(t *testing.T) {
+	k := New("foo")
+	err := k.New("bar")
+	assert.Equal(t, k.Is(err), true)
+	assert.Equal(t, k.Is(io.EOF), false)
+	assert.Equal(t, k.Is(nil), false)
+}
+
+func TestKindIsChildren(t *testing.T) {
+	k := New("foo")
+	err := k.Wrap(io.EOF)
+	assert.Equal(t, k.Is(err), true)
+}
+
+func TestError(t *testing.T) {
+	err := New("foo %s").New("bar")
+	assert.Equal(t, err.Error(), "foo bar")
+}
+
+func TestErrorCause(t *testing.T) {
+	err := New("foo").Wrap(io.EOF)
+	assert.Equal(t, err.Error(), "foo: EOF")
+}

--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ExampleNew() {
-	var ErrExample = errors.New("example")
+	var ErrExample = errors.NewKind("example")
 
 	err := ErrExample.New()
 	if ErrExample.Is(err) {
@@ -19,7 +19,7 @@ func ExampleNew() {
 }
 
 func ExampleNew_format() {
-	var ErrMaxLimitReached = errors.New("max. limit reached: %d")
+	var ErrMaxLimitReached = errors.NewKind("max. limit reached: %d")
 
 	err := ErrMaxLimitReached.New(42)
 	if ErrMaxLimitReached.Is(err) {
@@ -30,7 +30,7 @@ func ExampleNew_format() {
 }
 
 func ExampleKind_Wrap() {
-	var ErrNetworking = errors.New("network error")
+	var ErrNetworking = errors.NewKind("network error")
 
 	err := ErrNetworking.Wrap(io.EOF)
 	if ErrNetworking.Is(err) {
@@ -41,8 +41,8 @@ func ExampleKind_Wrap() {
 }
 
 func ExampleKind_Wrap_nested() {
-	var ErrNetworking = errors.New("network error")
-	var ErrReading = errors.New("reading error")
+	var ErrNetworking = errors.NewKind("network error")
+	var ErrReading = errors.NewKind("reading error")
 
 	err3 := io.EOF
 	err2 := ErrReading.Wrap(err3)
@@ -55,8 +55,8 @@ func ExampleKind_Wrap_nested() {
 }
 
 func ExampleAny() {
-	var ErrNetworking = errors.New("network error")
-	var ErrReading = errors.New("reading error")
+	var ErrNetworking = errors.NewKind("network error")
+	var ErrReading = errors.NewKind("reading error")
 
 	err := ErrNetworking.New()
 	if errors.Any(err, ErrReading, ErrNetworking) {

--- a/example_test.go
+++ b/example_test.go
@@ -18,7 +18,7 @@ func ExampleNew() {
 	// Output: example
 }
 
-func ExampleNewFormat() {
+func ExampleNew_format() {
 	var ErrMaxLimitReached = errors.New("max. limit reached: %d")
 
 	err := ErrMaxLimitReached.New(42)
@@ -29,7 +29,7 @@ func ExampleNewFormat() {
 	// Output: max. limit reached: 42
 }
 
-func ExampleWrap() {
+func ExampleKind_Wrap() {
 	var ErrNetworking = errors.New("network error")
 
 	err := ErrNetworking.Wrap(io.EOF)
@@ -40,7 +40,7 @@ func ExampleWrap() {
 	// Output: network error: EOF
 }
 
-func ExampleNestedWrap() {
+func ExampleKind_Wrap_nested() {
 	var ErrNetworking = errors.New("network error")
 	var ErrReading = errors.New("reading error")
 
@@ -54,12 +54,12 @@ func ExampleNestedWrap() {
 	// Output: network error: reading error: EOF
 }
 
-func ExampleAlternativeMultiple() {
+func ExampleAny() {
 	var ErrNetworking = errors.New("network error")
 	var ErrReading = errors.New("reading error")
 
 	err := ErrNetworking.New()
-	if errors.Is(err, ErrReading, ErrNetworking) {
+	if errors.Any(err, ErrReading, ErrNetworking) {
 		fmt.Println(err)
 	}
 

--- a/matcher.go
+++ b/matcher.go
@@ -1,26 +1,32 @@
 package errors
 
-// Matcher match a given error
+// Matcher matches a given error
 type Matcher interface {
-	// Is return true if the err match
+	// Is returns true if the err matches
 	Is(err error) bool
 }
 
-// Is check if err match all matchers
+// Is check if err matches all matchers
 func Is(err error, matchers ...Matcher) bool {
-	var are int
+	if len(matchers) == 0 {
+		return false
+	}
+
 	for _, m := range matchers {
-		if m.Is(err) {
-			are++
+		if !m.Is(err) {
+			return false
 		}
 	}
 
-	wanted := len(matchers)
-	return wanted == are
+	return true
 }
 
-// Any check if err match any matchers
+// Any checks if err matches any matchers
 func Any(err error, matchers ...Matcher) bool {
+	if len(matchers) == 0 {
+		return false
+	}
+
 	for _, m := range matchers {
 		if m.Is(err) {
 			return true

--- a/matcher.go
+++ b/matcher.go
@@ -1,33 +1,31 @@
 package errors
 
+// Matcher match a given error
 type Matcher interface {
-	Match(required ...*Kind) bool
+	// Is return true if the err match
+	Is(err error) bool
 }
 
+// Is check if err match all matchers
 func Is(err error, matchers ...Matcher) bool {
-	if err == nil {
-		return false
-	}
-
-	e, ok := err.(*Error)
-	if !ok {
-		return false
-	}
-
-	if e.Child != nil && Is(e.Child, matchers...) {
-		return true
-	}
-
+	var are int
 	for _, m := range matchers {
-		if m.Match(e.Kind) {
-			return true
+		if m.Is(err) {
+			are++
 		}
 	}
 
-	return false
+	wanted := len(matchers)
+	return wanted == are
 }
 
-func (k *Kind) matchChild(required ...*Kind) bool {
+// Any check if err match any matchers
+func Any(err error, matchers ...Matcher) bool {
+	for _, m := range matchers {
+		if m.Is(err) {
+			return true
+		}
+	}
 
 	return false
 }

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestIs(t *testing.T) {
-	k := New("foo")
+	k := NewKind("foo")
 	err := k.New("bar")
 
 	assert.Equal(t, Is(err, k), true)
@@ -16,20 +16,20 @@ func TestIs(t *testing.T) {
 }
 
 func TestIsMultiple(t *testing.T) {
-	k1 := New("foo")
+	k1 := NewKind("foo")
 	err1 := k1.New("bar")
 
-	k2 := New("qux")
+	k2 := NewKind("qux")
 	err2 := k2.Wrap(err1)
 
 	assert.Equal(t, Is(err2, k1, k2), true)
 }
 
 func TestAny(t *testing.T) {
-	k1 := New("foo")
+	k1 := NewKind("foo")
 	err := k1.New("bar")
 
-	k2 := New("qux")
+	k2 := NewKind("qux")
 
 	assert.Equal(t, Any(err, k1, k2), true)
 	assert.Equal(t, Any(io.EOF, k1, k2), false)

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -15,6 +15,10 @@ func TestIs(t *testing.T) {
 	assert.Equal(t, Is(io.EOF, k), false)
 }
 
+func TestIsEmpty(t *testing.T) {
+	assert.Equal(t, Is(nil), false)
+}
+
 func TestIsMultiple(t *testing.T) {
 	k1 := NewKind("foo")
 	err1 := k1.New("bar")
@@ -33,4 +37,8 @@ func TestAny(t *testing.T) {
 
 	assert.Equal(t, Any(err, k1, k2), true)
 	assert.Equal(t, Any(io.EOF, k1, k2), false)
+}
+
+func TestAnyEmpty(t *testing.T) {
+	assert.Equal(t, Any(nil), false)
 }

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1,0 +1,36 @@
+package errors
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIs(t *testing.T) {
+	k := New("foo")
+	err := k.New("bar")
+
+	assert.Equal(t, Is(err, k), true)
+	assert.Equal(t, Is(io.EOF, k), false)
+}
+
+func TestIsMultiple(t *testing.T) {
+	k1 := New("foo")
+	err1 := k1.New("bar")
+
+	k2 := New("qux")
+	err2 := k2.Wrap(err1)
+
+	assert.Equal(t, Is(err2, k1, k2), true)
+}
+
+func TestAny(t *testing.T) {
+	k1 := New("foo")
+	err := k1.New("bar")
+
+	k2 := New("qux")
+
+	assert.Equal(t, Any(err, k1, k2), true)
+	assert.Equal(t, Any(io.EOF, k1, k2), false)
+}


### PR DESCRIPTION
# Context 

This is a proposal to introduce a better error handling in all our code bases.

I tried to collect all the common problem we have nowadays in the error handling, an suggest a solution. 

The terminology used here is extracted from: [Don’t just check errors, handle them gracefully - Dave Cheney](https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully), what is a required lecture to have a fully understanding of the possible solutions, being this solutions a kind of nemesis to the Dave's solutions.

Is interesting to take a look to  [`pkg/errors`](https://github.com/pkg/errors) an error package implemented by Cheney, based on avoid sentinel errors. 

Also please take a look to the examples contained in the [package documentation](https://godoc.org/github.com/mcuadros/errors#pkg-examples)

# Issues and suggest solutions

All the solution you can find here is based on the premise that we like the sentinel errors and we want to avoid opaque errors

### Sentinel errors with un-precise text:
Returning sentinel errors, you can't customize the text, for example in this case can be desiderable, include the name of the unknown capability  [`context`](https://github.com/src-d/go-git/blob/963c1902967140ec6c3f6310cbe2f730590d0065/plumbing/protocol/packp/capability/list.go#L122-L124)

```go
var ErrUnknownCapability = errors.New("unknown capability")
...
if _, ok := valid[c]; !ok {
	return ErrUnknownCapability
}
```

Solution:
```go
var ErrMaxLimitReached = errors.New("unknown capability: %s")
...
if _, ok := valid[c]; !ok {
	return ErrUnknownCapability.New(c)
}
```

### Precise error but opaque errors
We return errors created on-the-fly with `fmt.Errorf` having precise information about the error like:  [`context`](https://github.com/src-d/go-git/blob/9eb101fc4626da68df42b50bfb4d574fd23b87d7/plumbing/transport/client/client.go#L31-L34)

```go
f, ok := Protocols[endpoint.Scheme]
if !ok {
	return nil, fmt.Errorf("unsupported scheme %q", endpoint.Scheme)
}
```

But being an opaque error that cannot be asserted in anyway (only by ` Errror()`  :warning:), this is solved in the same way of the previous issue:

```go
var ErrUnsupportedScheme = errors.New("unsupported scheme %q")
...go
f, ok := Protocols[endpoint.Scheme]
if !ok {
	return ErrUnsupportedScheme.New(endpoint.Scheme)
}
```

### Sentinel errors converted to opaque errors

Other problem can be converting sentinel error in opaque errors, we are losing information (important or not) for the caller. [`context`](https://github.com/src-d/go-git/blob/9eb101fc4626da68df42b50bfb4d574fd23b87d7/plumbing/transport/internal/common/common.go#L406-L409)

```go
res := packp.NewUploadPackResponse(req)
if err := res.Decode(r); err != nil {
	return nil, fmt.Errorf("error decoding upload-pack response: %s", err)
}
```

In the example if we want assert if the error was a io timeout error, to retry, is complete impossible do this.


```go
var ErrDecodingResponse = errors.New("error decoding upload-pack response")
...
res := packp.NewUploadPackResponse(req)
if err := res.Decode(r); err != nil {
	return nil, ErrDecodingResponse.Wrap(err)
}
```

Using `Kind.Wrap` the cause of an error can be asserted by kind or any other method

### Generic errors without context
The oposite to the previous issue is if we return directly the error returned by another function, because is easy and we don't need to create our custom error. This is one of the worst cases, ending having a `io.EOF` that you don't have any clue where was generated [`context`](https://github.com/src-d/go-git/blob/9eb101fc4626da68df42b50bfb4d574fd23b87d7/plumbing/transport/internal/common/common.go#L302-L303)

```go
if _, err := s.Stdin.Write(pktline.FlushPkt); err != nil {
	return err
}
```

```go
var ErrSendingResponse = errors.New("error sending response")
...
if _, err := s.Stdin.Write(pktline.FlushPkt); err != nil {
	return nil, ErrSendingResponse.Wrap(err)
}
```


# Perks
- StackTrace on the error, if we use always this error library and we return a error generated by `Kind.New()`, we can include a stack trace on each error, having full context about it