### PR TITLE
Stacktrace and Causer interface

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ import (
 	"srcd.works/errors.v0"
 )
 
-func ExampleNew() {
+func ExampleKind_New() {
 	var ErrExample = errors.NewKind("example")
 
 	err := ErrExample.New()
@@ -18,7 +18,7 @@ func ExampleNew() {
 	// Output: example
 }
 
-func ExampleNew_format() {
+func ExampleKind_New_pattern() {
 	var ErrMaxLimitReached = errors.NewKind("max. limit reached: %d")
 
 	err := ErrMaxLimitReached.New(42)
@@ -52,6 +52,32 @@ func ExampleKind_Wrap_nested() {
 	}
 
 	// Output: network error: reading error: EOF
+}
+
+func ExampleError_printf() {
+	var ErrExample = errors.NewKind("example with stack trace")
+
+	err := ErrExample.New()
+	fmt.Printf("%+v\n", err)
+
+	// Example Output:
+	// example with stack trace
+	//
+	// srcd.works/errors%2v0_test.ExampleError_Format
+	//         /home/mcuadros/workspace/go/src/srcd.works/errors.v0/example_test.go:60
+	// testing.runExample
+	//         /usr/lib/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /usr/lib/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /usr/lib/go/src/testing/testing.go:744
+	// main.main
+	//         github.com/pkg/errors/_test/_testmain.go:106
+	// runtime.main
+	//         /usr/lib/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /usr/lib/go/src/runtime/asm_amd64.s:2086
+
 }
 
 func ExampleAny() {

--- a/stack.go
+++ b/stack.go
@@ -1,0 +1,28 @@
+package errors
+
+import (
+	"runtime"
+
+	"github.com/pkg/errors"
+)
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace struct {
+	errors.StackTrace
+}
+
+// NewStackTrace returns a new StackTrace, skipping the given number of frames,
+// to avoid including the caller
+func NewStackTrace(skip int) StackTrace {
+	const depth = 32
+
+	var pcs [depth]uintptr
+	n := runtime.Callers(2+skip, pcs[:])
+
+	f := make(errors.StackTrace, n)
+	for i := 0; i < n; i++ {
+		f[i] = errors.Frame(pcs[i])
+	}
+
+	return StackTrace{f}
+}

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCaller(t *testing.T) {
+	s := NewStackTrace(0)
+	assert.NotEmpty(t, s.StackTrace)
+
+	assert.Equal(t, fmt.Sprintf("%s", s), "[stack_test.go testing.go asm_amd64.s]")
+}
+
+func TestCallerSkip(t *testing.T) {
+	s := NewStackTrace(1)
+	assert.NotEmpty(t, s.StackTrace)
+
+	assert.Equal(t, fmt.Sprintf("%s", s), "[testing.go asm_amd64.s]")
+}

--- a/stack_test.go
+++ b/stack_test.go
@@ -4,19 +4,23 @@ import (
 	"fmt"
 	"testing"
 
+	"strings"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCaller(t *testing.T) {
 	s := NewStackTrace(0)
-	assert.NotEmpty(t, s.StackTrace)
+	assert.NotNil(t, s)
 
-	assert.Equal(t, fmt.Sprintf("%s", s), "[stack_test.go testing.go asm_amd64.s]")
+	o := fmt.Sprintf("%s", s)
+	assert.Equal(t, strings.HasPrefix(o, "[stack_test.go testing.go"), true)
 }
 
 func TestCallerSkip(t *testing.T) {
-	s := NewStackTrace(1)
-	assert.NotEmpty(t, s.StackTrace)
+	full := NewStackTrace(0)
+	assert.NotNil(t, full)
 
-	assert.Equal(t, fmt.Sprintf("%s", s), "[testing.go asm_amd64.s]")
+	s := NewStackTrace(1)
+	assert.Len(t, s.StackTrace, len(full.StackTrace)-1)
 }


### PR DESCRIPTION
This is the implementation of the stack trace and the `github.com/pkg/errors.Causer` interface.

The StackTrace object is based on the `github.com/pkg/errors.StackTrace` struct, being now a dependency of this project 