### PR TITLE
Small doc, CI and modules updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: go
 
-go:
-    - 1.8
-
 go_import_path: gopkg.in/src-d/go-errors.v1
+
+go:
+    - 1.11
+    - 1.12
 
 install:
   - go get -v -t ./...
@@ -13,3 +14,10 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+jobs:
+  include:
+    - name: 'Go Modules'
+      install:
+      script:
+        - GO111MODULE=on make test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-errors [![GoDoc](https://godoc.org/gopkg.in/src-d/go-errors.v1?status.svg)](https://godoc.org/gopkg.in/src-d/go-errors.v1) [![Build Status](https://travis-ci.org/src-d/go-errors.svg?branch=master)](https://travis-ci.org/src-d/go-errors) [![codecov](https://codecov.io/gh/src-d/go-errors/branch/master/graph/badge.svg)](https://codecov.io/gh/src-d/go-errors) [![codebeat badge](https://codebeat.co/badges/e0c5d481-6200-4112-9144-f750317421f0)](https://codebeat.co/projects/github-com-src-d-go-errors)
+# go-errors [![GoDoc](https://godoc.org/gopkg.in/src-d/go-errors.v1?status.svg)](https://godoc.org/gopkg.in/src-d/go-errors.v1) [![Build Status](https://travis-ci.com/src-d/go-errors.svg?branch=master)](https://travis-ci.com/src-d/go-errors) [![codecov](https://codecov.io/gh/src-d/go-errors/branch/master/graph/badge.svg)](https://codecov.io/gh/src-d/go-errors) [![codebeat badge](https://codebeat.co/badges/e0c5d481-6200-4112-9144-f750317421f0)](https://codebeat.co/projects/github-com-src-d-go-errors)
 
 Yet another `errors` package, implementing error handling primitives with error wrapping and error tracing.
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module gopkg.in/src-d/go-errors.v1
+
+go 1.11
+
+require (
+	github.com/pkg/errors v0.8.1
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
A small drive-by improvements:

 - doc: link for CI badge change to .com to fix image rendering in README

   Before <img width="762" alt="Screen Shot 2019-05-30 at 10 32 51 AM" src="https://user-images.githubusercontent.com/5582506/58620044-6f108580-82c6-11e9-8800-3d1c0999e5a9.png">
    After  <img width="652" alt="Screen Shot 2019-05-30 at 11 11 33 AM" src="https://user-images.githubusercontent.com/5582506/58622380-c402ca80-82cb-11e9-9684-385949e60807.png">

  - CI updated to include 2 latest profiles, following [src-d Go conventions for libraries](https://github.com/src-d/guide/blob/master/engineering/conventions/go.md#supported-go-versions)

  - go module definition for `gopkg.in/src-d/go-errors.v1` added
    This way, downstream Go 1.11+ clients can benefit from a module-awareness.
    It's not mandatory and CI now includes several profiles, to make sure it works with and without modules. Comes with affordable CI build time increase: [before](https://travis-ci.org/src-d/go-errors/builds/257933401): `1 min 7 sec`, [after](https://travis-ci.com/bzz/go-errors/builds/113719480) `1 min 52 sec` 
