### PR TITLE
Expose error Kind

### DIFF
--- a/error.go
+++ b/error.go
@@ -67,6 +67,11 @@ type Error struct {
 	stack   StackTrace
 }
 
+// Kind returns a kind of the error
+func (err *Error) Kind() *Kind {
+	return err.kind
+}
+
 // Cause returns the underlying cause of the error
 func (err *Error) Cause() error {
 	return err.cause


### PR DESCRIPTION
`Error.Kind()` is not useful in regular code, but it is needed when writing tests. One use case is to check `Kind` and `Cause` or two error values recursively to make sure errors are the same.

Signed-off-by: Denys Smirnov <denys@sourced.tech>